### PR TITLE
Fix the VW service selector

### DIFF
--- a/chart/byconity/templates/vw-service.yaml
+++ b/chart/byconity/templates/vw-service.yaml
@@ -12,6 +12,7 @@ spec:
   type: ClusterIP
   selector:
     {{- include "byconity.selectorLabels" $ | nindent 4 }}
+    byconity-vw: {{ .name }}
     byconity-role: worker
   ports:
     - name: port0


### PR DESCRIPTION
The VW service should only select the corresponding pods (for example, only the write pods) rather than all the worker pods.

Otherwise we would have had the issue like below
![image](https://github.com/ByConity/byconity-deploy/assets/2840571/f516c7a9-7844-4b3b-924a-2dbfd0e40d85)
