### PR TITLE
Add custom virtual_warehouse_id and worker_group_id

### DIFF
--- a/chart/byconity/templates/vw.yaml
+++ b/chart/byconity/templates/vw.yaml
@@ -41,9 +41,17 @@ spec:
             {{- toYaml $.Values.byconity.additionalEnvs | nindent 12 }}
           {{- end }}
             - name: VIRTUAL_WAREHOUSE_ID
-              value: {{ .name }}
+              {{- if .virtual_warehouse_id }}
+                value: {{ .virtual_warehouse_id }}
+              {{- else }}
+                value: {{ .name }}
+              {{- end }}
             - name: WORKER_GROUP_ID
-              value: {{ .name }}
+              {{- if .worker_group_id }}
+                value: {{ .worker_group_id }}
+              {{- else }}
+                value: {{ .name }}
+              {{- end }}
             - name: WORKER_ID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
I added 'virtual_warehouse_id' and 'worker_group_id'.

When using, simply configure 'virtual_warehouse_id: xxx' and 'worker_group_id: xxx' to use, with 'name' used by default

```
  virtualWarehouses:
    - <<: *defaultWorker
      name: vw_default
      virtual_warehouse_id: xxx
      worker_group_id: xxx
      replicas: 1

```

https://github.com/ByConity/byconity-deploy/issues/43